### PR TITLE
Recover to catch panics and return as error

### DIFF
--- a/geojson/geojson.go
+++ b/geojson/geojson.go
@@ -28,12 +28,15 @@ const (
 )
 
 // Parse parses a GeoJSON string into a GeoJSON object pointer
-func Parse(bytes []byte) (interface{}, error) {
-	var (
-		result interface{}
-		gj     map[string]interface{}
-		err    error
-	)
+func Parse(bytes []byte) (result interface{}, err error) {
+	var gj map[string]interface{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+
 	if err = json.Unmarshal(bytes, &gj); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I tested your library with thousands of GeoJSON files and discover that it panics for several kinds of malformed input files.

This PR just adds a `recover` in the API entrypoint to catch all kinds of panics due to invalid data and return a graceful error to the client.

Let me know if this is useful somehow.

Thanks for the library.

Closes #3 