### PR TITLE
Fix coordinate corruption when calculating bbox

### DIFF
--- a/geojson/bbox.go
+++ b/geojson/bbox.go
@@ -60,10 +60,20 @@ func NewBoundingBox(input interface{}) (BoundingBox, error) {
 		case 0, 1:
 			// No op
 		case 2:
-			result = append(inputType, inputType[:]...)
+			result = []float64{
+				inputType[0],
+				inputType[1],
+				inputType[0],
+				inputType[1]}
 			// Drop extraneous coordinates like measurements that do not pertain to BBoxes
 		default:
-			result = append(inputType[0:3], inputType[0:3]...)
+			result = []float64{
+				inputType[0],
+				inputType[1],
+				inputType[2],
+				inputType[0],
+				inputType[1],
+				inputType[2]}
 		}
 	case [][]float64:
 		for _, curr := range inputType {


### PR DESCRIPTION
The current bbox calculation has a nasty bug where the underlying geometry is corrupted when calculating its bounding box. I haven't tracked down exactly where the error is, but it is most likely related to the float64 slice's underlying memory being modified by the calls to ```append()```