### PR TITLE
Fix parse input corruption

### DIFF
--- a/geojson/bbox.go
+++ b/geojson/bbox.go
@@ -60,10 +60,20 @@ func NewBoundingBox(input interface{}) (BoundingBox, error) {
 		case 0, 1:
 			// No op
 		case 2:
-			result = append(inputType, inputType[:]...)
+			result = []float64{
+				inputType[0],
+				inputType[1],
+				inputType[0],
+				inputType[1]}
 			// Drop extraneous coordinates like measurements that do not pertain to BBoxes
 		default:
-			result = append(inputType[0:3], inputType[0:3]...)
+			result = []float64{
+				inputType[0],
+				inputType[1],
+				inputType[2],
+				inputType[0],
+				inputType[1],
+				inputType[2]}
 		}
 	case [][]float64:
 		for _, curr := range inputType {

--- a/geojson/bbox_test.go
+++ b/geojson/bbox_test.go
@@ -213,3 +213,48 @@ func testBBox(t *testing.T, fileName string) {
 		t.Errorf("Bounding box for %v is empty: %v", fileName, gj.(fmt.Stringer).String())
 	}
 }
+
+func TestBboxParseNoSideEffects(t *testing.T) {
+	checkInputUnchanged := func(expected []float64, actual []float64) {
+		if len(expected) != len(actual) {
+			t.Errorf("Bounding box constructor changed input data size; Expected: %d; Actual: %d", len(expected), len(actual))
+		} else {
+			for i := range expected {
+				if expected[i] != actual[i] {
+					t.Errorf("Bounding box constructor modified input data; Expected: %v; Actual: %v", expected, actual)
+					break
+				}
+			}
+		}
+	}
+	var originalData, passedInData []float64
+
+	// Tests for invalid (too few) valid
+	originalData = []float64{}
+	passedInData = append([]float64{}, originalData...)
+	NewBoundingBox(passedInData)
+	checkInputUnchanged(originalData, passedInData)
+
+	originalData = []float64{1}
+	passedInData = append([]float64{}, originalData...)
+	NewBoundingBox(passedInData)
+	checkInputUnchanged(originalData, passedInData)
+
+	// Test for two values
+	originalData = []float64{1, 2}
+	passedInData = append([]float64{}, originalData...)
+	NewBoundingBox(passedInData)
+	checkInputUnchanged(originalData, passedInData)
+
+	// Test for three values
+	originalData = []float64{1, 2, 3}
+	passedInData = append([]float64{}, originalData...)
+	NewBoundingBox(passedInData)
+	checkInputUnchanged(originalData, passedInData)
+
+	// Test for three values plus extraneous data
+	originalData = []float64{1, 2, 3, 4, 5, 6, 7}
+	passedInData = append([]float64{}, originalData...)
+	NewBoundingBox(passedInData)
+	checkInputUnchanged(originalData, passedInData)
+}


### PR DESCRIPTION
Original pull request from @tbonfort is here: https://github.com/venicegeo/geojson-go/pull/5

This PR includes a unit test to verify the fix.