### PR TITLE
Always include properties when marshaling features

### DIFF
--- a/geojson/feature.go
+++ b/geojson/feature.go
@@ -36,7 +36,7 @@ const (
 type Feature struct {
 	Type       string                 `json:"type"`
 	Geometry   interface{}            `json:"geometry"`
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	Properties map[string]interface{} `json:"properties"`
 	ID         interface{}            `json:"id,omitempty"`
 	Bbox       BoundingBox            `json:"bbox,omitempty"`
 }

--- a/geojson/feature_test.go
+++ b/geojson/feature_test.go
@@ -132,3 +132,29 @@ func TestRTFeature(t *testing.T) {
 		t.Errorf("Round trip feature failed: %v", f2.String())
 	}
 }
+
+func TestFeatureMarshalEmptyProperties(t *testing.T) {
+	var (
+		gj          interface{}
+		err         error
+		resultEmpty = `{"type":"Feature","geometry":{"type":"LineString","coordinates":[[102,0],[103,1],[104,0],[105,1]]},"properties":{},"id":98765}`
+		resultNil   = `{"type":"Feature","geometry":{"type":"LineString","coordinates":[[102,0],[103,1],[104,0],[105,1]]},"properties":null,"id":98765}`
+	)
+
+	if gj, err = ParseFile("test/feature.geojson"); err != nil {
+		t.Errorf("Failed to parse file: %v", err)
+	}
+	f := gj.(*Feature)
+
+	// Test empty properties map
+	f.Properties = map[string]interface{}{}
+	if f.String() != resultEmpty {
+		t.Errorf("Empty properties did not output an empty object: %v", f.String())
+	}
+
+	// Test nil properties map
+	f.Properties = nil
+	if f.String() != resultNil {
+		t.Errorf("Nil properties did not output an empty object: %v", f.String())
+	}
+}

--- a/geojson/geojson_test.go
+++ b/geojson/geojson_test.go
@@ -154,11 +154,11 @@ func TestNullInputs(t *testing.T) {
 		t.Errorf("Received %v for empty Feature Collection.", fc.String())
 	}
 	f := NewFeature(nil, nil, nil)
-	if f.String() != `{"type":"Feature","geometry":null}` {
+	if f.String() != `{"type":"Feature","geometry":null,"properties":{}}` {
 		t.Errorf("Received %v for an empty Feature.", f.String())
 	}
 	fc.Features = append(fc.Features, f)
-	if fc.String() != `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":null}]}` {
+	if fc.String() != `{"type":"FeatureCollection","features":[{"type":"Feature","geometry":null,"properties":{}}]}` {
 		t.Errorf("Received %v for a feature collection with a single empty feature", fc.String())
 	}
 }


### PR DESCRIPTION
Changes:

- Removed `omitempty` flag from Feature JSON definition for properties
- Added test verifying this behavior
- Altered existing tests to expect properties to be there