### PR TITLE
Recover to catch panics and return as error, plus testing

### DIFF
--- a/geojson/geojson.go
+++ b/geojson/geojson.go
@@ -28,12 +28,15 @@ const (
 )
 
 // Parse parses a GeoJSON string into a GeoJSON object pointer
-func Parse(bytes []byte) (interface{}, error) {
-	var (
-		result interface{}
-		gj     map[string]interface{}
-		err    error
-	)
+func Parse(bytes []byte) (result interface{}, err error) {
+	var gj map[string]interface{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+
 	if err = json.Unmarshal(bytes, &gj); err != nil {
 		return nil, err
 	}

--- a/geojson/geojson.go
+++ b/geojson/geojson.go
@@ -18,6 +18,7 @@ package geojson
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 )
 
@@ -29,13 +30,22 @@ const (
 
 // Parse parses a GeoJSON string into a GeoJSON object pointer
 func Parse(bytes []byte) (result interface{}, err error) {
-	var gj map[string]interface{}
-
 	defer func() {
 		if r := recover(); r != nil {
-			err = r.(error)
+			if parseErr, ok := r.(error); ok {
+				err = parseErr
+			} else {
+				err = fmt.Errorf("unexpected panic: %v", r)
+			}
 		}
 	}()
+	return parsePanicUnsafe(bytes)
+}
+
+// parsePanicUnsafe is the place Parse actually does its work,
+// but is implemented as a variable for stubbing in testing panic safety
+var parsePanicUnsafe = func(bytes []byte) (result interface{}, err error) {
+	var gj map[string]interface{}
 
 	if err = json.Unmarshal(bytes, &gj); err != nil {
 		return nil, err


### PR DESCRIPTION
Supersedes #4 
Closes #3 

Augmented the code supplied by @tiago4orion by providing proper test harnessing and unit testing of the panic recovery.